### PR TITLE
Fix typo in 10 Commandments of Tact documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Tact features modern post-C syntax familiar to developers who know TypeScript, S
 Tact makes it easy to declare, decode and encode data structures according to their TL-B schemas.
 
 3. Safe contract interfaces and ABI
-Tact offers strong compile-time checks for contract interfaces, typed addresses and lets describe messages natively in a subset of TL-B.
+Tact offers strong compile-time checks for contract interfaces, typed addresses and lets you describe messages natively in a subset of TL-B.
 
 4. Message dispatch
 Tact offers a convenient yet flexible way to declare, receive and send messages between contracts.


### PR DESCRIPTION
The text provided is already quite comprehensive and well-written. However, there is a minor typo in the "10 Commandments of Tact" section, specifically in point 3. The word "lets" should be corrected to "lets you." Here's the improved line:

Original:
"Tact offers strong compile-time checks for contract interfaces, typed addresses and lets describe messages natively in a subset of TL-B."

Improved:
"Tact offers strong compile-time checks for contract interfaces, typed addresses and lets you describe messages natively in a subset of TL-B."